### PR TITLE
Properly handle dots and slashes in query

### DIFF
--- a/vlasisku/components/app.py
+++ b/vlasisku/components/app.py
@@ -1,4 +1,4 @@
-
+import urllib
 from flask import Module, request, redirect, url_for
 from flaskext.genshi import render_response
 
@@ -15,7 +15,12 @@ app = Module(__name__)
 def index():
     db = database.root
     if 'query' in request.args:
-        return redirect(url_for('query', query=request.args.get('query')))
+        query_str = request.args.get('query')
+
+        # Manually escape '.' so it does not get interpreted as part of a
+        # relative path.
+        escaped_query = urllib.quote_plus(query_str).replace(".", "%2E")
+        return redirect(url_for("query", query="") + escaped_query)
     types = [(t[0], t[1], t[0].replace('-', ' ')) for t in TYPES]
     classes = set(e.grammarclass for e in db.entries.itervalues()
                                  if e.grammarclass)
@@ -24,7 +29,7 @@ def index():
     return render_response('index.html', locals())
 
 
-@app.route('/<query>')
+@app.route('/<path:query>')
 @etag
 def query(query):
     db = database.root


### PR DESCRIPTION
Fixes #16.

Changes:
- Manually escape dots in query text so searching ".." doesn't lead to an error.
- Change url parameter for the query route to a path parameter, so that it accepts slashes. Searching "date/time/event" no longer leads to error.

Before, looking up "." would lead to a reload, since the dot is interpreted as a relative path to the current directory. Now, it correctly takes you to the definition of depybu'i. In addition, looking up queries with slashes no longer lead to errors, since slashes are quoted by `urllib.quote_plus`.

Tests are not passing but I think they have to do with database changes. For example,
```
======================================================================
FAIL: Doctest: vlasisku.database.Root.query
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/doctest.py", line 2224, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for vlasisku.database.Root.query
  File "/srv/lojban/vlasisku/vlasisku/database.py", line 241, in query

----------------------------------------------------------------------
File "/srv/lojban/vlasisku/vlasisku/database.py", line 245, in vlasisku.database.Root.query
Failed example:
    len(database.root.query('class:UI4')['matches'])
Expected:
    6
Got:
    8
```