### PR TITLE
Add warning for experimental and compound cmavo in class search

### DIFF
--- a/vlasisku/components/app.py
+++ b/vlasisku/components/app.py
@@ -41,6 +41,12 @@ def query(query):
     if not results['entry'] and len(results['matches']) == 1:
         return redirect(url_for('app.query', query=results['matches'].pop()))
 
+    for entry in results['classes']:
+        if entry.type == 'experimental cmavo':
+            entry.warning = 'exp!'
+        elif entry.type == 'cmavo-compound':
+            entry.warning = 'comp!'
+
     sourcemetaphor = []
     unknownaffixes = None
     similar = None

--- a/vlasisku/templates/entrylist.html
+++ b/vlasisku/templates/entrylist.html
@@ -3,7 +3,7 @@
     <h2>{{ title }}</h2>
     <dl>
         {% for entry in entries %}
-        <dt><a href="{{ entry }}">{{ entry }}</a></dt>
+        <dt><a href="{{ entry }}">{{ entry }}</a> {% if entry.warning %}<i title="this is a {{entry.type}}">({{entry.warning}})</i>{% endif %}</dt>
         <dd>{{ entry.definition|safe }}</dd>
         {% endfor %}
     </dl>


### PR DESCRIPTION
When searching cmavo by class, there is currently no obvious indication of experimental vs non-experimental results. This PR adds a small indicator for results that are not strictly of type "cmavo", that is, those that are "experimental cmavo" or "cmavo-compound".