### PR TITLE
Turn off autocorrection attributes

### DIFF
--- a/vlasisku/templates/custom.js
+++ b/vlasisku/templates/custom.js
@@ -12,5 +12,8 @@ jQuery(function ($) {
     });
     $(window).load(function () {
         $('#query').attr('autocomplete', 'off');
+        $('#query').attr('autocapitalize', 'off');
+        $('#query').attr('autocorrect', 'off');
+        $('#query').attr('spellcheck', 'false');
     });
 });


### PR DESCRIPTION
Turning off autocomplete, autocorrect, and spellcheck makes it easier to enter lojban on mobile devices.